### PR TITLE
Feature mbed

### DIFF
--- a/src/CobsSerial.hpp
+++ b/src/CobsSerial.hpp
@@ -2,6 +2,7 @@
 #define _COBS_SERIAL_HPP_
 
 #include <stdint.h>
+#include <cstring>
 
 #include "SerialDev.hpp"
 

--- a/src/MbedHardwareSerial.hpp
+++ b/src/MbedHardwareSerial.hpp
@@ -1,0 +1,52 @@
+#ifndef _MBED_HARDWARE_SERIAL
+#define _MBED_HARDWARE_SERIAL
+
+#include "mbed.h"
+
+#include "SerialDev.hpp"
+#include "CobsSerial.hpp"
+
+#define RX_QUEUE_SIZE 64
+
+class MbedHardwareSerial : public SerialDev
+{
+public:
+    MbedHardwareSerial(Serial *dev) : _rx_queue(RX_QUEUE_SIZE)
+    {
+        _dev = dev;
+        _dev->attach(callback(this, &MbedHardwareSerial::_serial_rx), Serial::RxIrq);
+    }
+
+    virtual int read()
+    {
+        uint8_t data = _rx_queue.front();
+        _rx_queue.pop();
+        return data;
+    }
+
+    virtual int readable_len()
+    {
+        return _rx_queue.size();
+    }
+
+    virtual int write(unsigned char *data, unsigned int len)
+    {
+        for(int i = 0; i < len; i++){
+            _dev->putc(data[i]);
+        }
+        return len;
+    }
+
+private:
+    void _serial_rx(void)
+    {
+        while (_dev->readable()) {
+            unsigned char c = _dev->getc();
+            _rx_queue.push(c);
+        }
+    }
+
+    Serial *_dev;
+    ring_queue<uint8_t> _rx_queue;
+};
+#endif

--- a/src/source/CobsSerial.cpp
+++ b/src/source/CobsSerial.cpp
@@ -13,7 +13,7 @@ int CobsSerial::read(uint8_t *data, const unsigned int max_len)
 {
     int cnt = 0;
     uint8_t tmp[max_len];
-    memset(tmp, 0, max_len);
+    std::memset(tmp, 0, max_len);
 
     if(!_data_begin && _got_packet){
         uint8_t val = 1;

--- a/src/source/CobsSerial.cpp
+++ b/src/source/CobsSerial.cpp
@@ -12,7 +12,8 @@ CobsSerial::CobsSerial(SerialDev *dev)
 int CobsSerial::read(uint8_t *data, const unsigned int max_len)
 {
     int cnt = 0;
-    uint8_t tmp[max_len] = {};
+    uint8_t tmp[max_len];
+    memset(tmp, 0, max_len);
 
     if(!_data_begin && _got_packet){
         uint8_t val = 1;


### PR DESCRIPTION
Overview
Add support for developing with Mbed.

Implementation
- Use std:memset() for initializing array because of mbed's compiler does not support
- Add MbedHardwareSerial.hpp for Mbed