### PR TITLE
Feature fix cobs serial

### DIFF
--- a/src/CobsSerial.hpp
+++ b/src/CobsSerial.hpp
@@ -6,9 +6,6 @@
 
 #include "SerialDev.hpp"
 
-#define COBS_TX_BUFFER_SIZE 64
-#define COBS_RX_BUFFER_SIZE 256
-
 template <typename Type_t>
 class ring_queue
 {
@@ -69,6 +66,10 @@ public:
     int write(uint8_t *data, const unsigned int len);
 
     void update();
+
+    enum{
+        RX_BUFFER_SIZE = 256,
+    };
 
 private:
     SerialDev *_dev;

--- a/src/CobsSerial.hpp
+++ b/src/CobsSerial.hpp
@@ -79,5 +79,3 @@ private:
 };
 
 #endif //#ifndef _COBS_SERIAL_HPP_
-
-//Backtrace: 0x400d5bee:0x3ffb1e60 0x400d114c:0x3ffb1f90 0x400d8615:0x3ffb1fb0 0x40086a7d:0x3ffb1fd0

--- a/src/CobsSerial.hpp
+++ b/src/CobsSerial.hpp
@@ -64,7 +64,7 @@ class CobsSerial
 public:
     CobsSerial(SerialDev *dev);
 
-    int read(uint8_t *data, const unsigned int max_len = 32);
+    int read(uint8_t *data);
 
     int write(uint8_t *data, const unsigned int len);
 

--- a/src/source/CobsSerial.cpp
+++ b/src/source/CobsSerial.cpp
@@ -9,11 +9,10 @@ CobsSerial::CobsSerial(SerialDev *dev)
     _got_packet = false;
 }
 
-int CobsSerial::read(uint8_t *data, const unsigned int max_len)
+int CobsSerial::read(uint8_t *data)
 {
     int cnt = 0;
-    uint8_t tmp[max_len];
-    std::memset(tmp, 0, max_len);
+    uint8_t tmp[COBS_RX_BUFFER_SIZE];
 
     if(!_data_begin && _got_packet){
         uint8_t val = 1;
@@ -36,7 +35,8 @@ int CobsSerial::read(uint8_t *data, const unsigned int max_len)
 
 int CobsSerial::write(uint8_t *data, const unsigned int len)
 {
-    uint8_t tmp[COBS_TX_BUFFER_SIZE] = {};
+    uint8_t tmp[len+3];
+    std::memset(tmp, 0, len+3);
     int tx_size = cobsEncode(data, len, tmp+1); //先頭の次にcobsコードを代入
     return _dev->write(tmp, tx_size+2);
 }

--- a/src/source/CobsSerial.cpp
+++ b/src/source/CobsSerial.cpp
@@ -3,7 +3,7 @@
 #include "../cobs.hpp"
 
 CobsSerial::CobsSerial(SerialDev *dev)
-    : _rx_buffer(COBS_RX_BUFFER_SIZE)
+    : _rx_buffer(RX_BUFFER_SIZE)
 {
     _dev = dev;
     _got_packet = false;
@@ -12,7 +12,7 @@ CobsSerial::CobsSerial(SerialDev *dev)
 int CobsSerial::read(uint8_t *data)
 {
     int cnt = 0;
-    uint8_t tmp[COBS_RX_BUFFER_SIZE];
+    uint8_t tmp[RX_BUFFER_SIZE];
 
     if(!_data_begin && _got_packet){
         uint8_t val = 1;

--- a/src/source/SerialBridge.cpp
+++ b/src/source/SerialBridge.cpp
@@ -44,7 +44,7 @@ int SerialBridge::rm_frame(frame_id id)
 
 int SerialBridge::read()
 {
-    uint8_t tmp[COBS_RX_BUFFER_SIZE] = {};
+    uint8_t tmp[CobsSerial::RX_BUFFER_SIZE] = {};
     int len = _dev->read(tmp) - 1;
     if(len > 0){
         int order = _id_2_order(tmp[0]);

--- a/src/source/SerialBridge.cpp
+++ b/src/source/SerialBridge.cpp
@@ -45,7 +45,7 @@ int SerialBridge::rm_frame(frame_id id)
 int SerialBridge::read()
 {
     uint8_t tmp[COBS_RX_BUFFER_SIZE] = {};
-    int len = _dev->read(tmp, COBS_RX_BUFFER_SIZE) - 1;
+    int len = _dev->read(tmp) - 1;
     if(len > 0){
         int order = _id_2_order(tmp[0]);
 


### PR DESCRIPTION
変更点
- CobsSerial::writeの不必要な長さのバッファーを廃止。
- CobsSerial::readの冗長な引数を削除、バッファサイズをクラス列挙型内で定義するように変更。
- 余分なコメントの削除。
- 依存関係にある処理の調整。