### PR TITLE
fix: mbed hang issue

### DIFF
--- a/src/source/MbedHardwareSerial.cpp
+++ b/src/source/MbedHardwareSerial.cpp
@@ -78,7 +78,7 @@ int MbedHardwareSerial::readable_len()
 
 #if MBED_MAJOR_VERSION >= 6
 
-    return _dev->size();
+    return _dev->readable();
 
 #else //mbed-os 6 and earlier versions.
 


### PR DESCRIPTION
We had designed non-blocking UART system, but it was hanging lol.
I fixed this problem by replacing BufferedSerial::size() to BufferedSerial::readable().